### PR TITLE
Convert LICENSE to Markdown

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,0 @@
-This program is free software; you can redistribute it and/or modify it under the terms of the <a href="http://www.gnu.org/licenses/gpl.html">GNU General Public License</a> as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
-
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the <a href="http://www.gnu.org/licenses/gpl.html">GNU General Public License</a> for more details.
-
-You should have received a copy of the <a href="http://www.gnu.org/licenses/gpl.html">GNU General Public License</a> along with this program; if not, write to the Free Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-
-This software utilizes a pkware explode implementation written by Mark Adler, please see blast.h for licensing details.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,7 @@
+This program is free software; you can redistribute it and/or modify it under the terms of the [GNU General Public License](http://www.gnu.org/licenses/gpl.html) as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [GNU General Public License](http://www.gnu.org/licenses/gpl.html) for more details.
+
+You should have received a copy of the [GNU General Public License](http://www.gnu.org/licenses/gpl.html) along with this program; if not, write to the Free Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+This software utilizes a pkware explode implementation written by Mark Adler, please see blast.h for licensing details.


### PR DESCRIPTION
With this change, the links will appear as links instead of as raw HTML.